### PR TITLE
Install using setuptools, not pip

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     - name: Install package
       shell: bash -l {0}
       run: |
-        python -m pip install --no-deps .
+        python setup.py develop --no-deps
 
     - name: Run tests
       shell: bash -l {0}


### PR DESCRIPTION
I'm not sure why this works, but it worked over in `openff-recharge`. See linked commit in commit message.