### PR TITLE
Depend on development versions of OpenFF Toolkit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,15 +2,8 @@ name: ci
 
 on:
   push:
-    branches:
-      - "master"
-      - "maintenance/.+"
   pull_request:
-    branches:
-      - "master"
-      - "maintenance/.+"
   schedule:
-    # Run a cron job once daily
     - cron: "0 0 * * *"
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,11 @@ jobs:
         conda info --all
         conda list
 
+    - name: Install development version of toolkit
+      shell: bash -l {0}
+      run: |
+        python -m pip install git+https://github.com/openforcefield/openforcefield
+
     - name: Install package
       shell: bash -l {0}
       run: |

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - pip
 
     # Core depends
-  - openforcefield > 0.7.1
+  - openforcefield # > 0.7.1
 
     # Testing
   - pytest

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - pip
 
     # Core depends
-  - openforcefield
+  - openforcefield > 0.7.1
 
     # Testing
   - pytest


### PR DESCRIPTION
Just making sure I can install from the development version (via pip) while depending on features that are between toolkit versions. This should be a straightforward lever to pull back and forth as needed, with the goal of not depending on a toolkit version long-term or within any particular releases.