### PR TITLE
Set up CI for RDKit/OpenEye split

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: goanpeca/setup-miniconda@v1
       name: Install both RDKit and OpenEye toolkits
-      if: ${{ matrix.cfg.openeye == 'TRUE' }}
+      if: ${{ matrix.openeye == 'TRUE' }}
       with:
         python-version: ${{ matrix.python-version }}
         activate-environment: test
@@ -33,7 +33,7 @@ jobs:
 
     - uses: goanpeca/setup-miniconda@v1
       name: Install only RDKit
-      if: ${{ matrix.cfg.openeye == 'FALSE' }}
+      if: ${{ matrix.openeye == 'FALSE' }}
       with:
         python-version: ${{ matrix.python-version }}
         activate-environment: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,15 +2,8 @@ name: ci
 
 on:
   push:
-    branches:
-      - "master"
-      - "maintenance/.+"
   pull_request:
-    branches:
-      - "master"
-      - "maintenance/.+"
   schedule:
-    # Run a cron job once daily
     - cron: "0 0 * * *"
 
 jobs:
@@ -21,6 +14,7 @@ jobs:
       matrix:
         os: [macOS-latest, ubuntu-latest]
         python-version: [3.6, 3.7]
+        openeye: ["true", "false"]
     env:
       PYVER: ${{ matrix.python-version }}
 
@@ -28,12 +22,37 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: goanpeca/setup-miniconda@v1
+      name: Install both RDKit and OpenEye toolkits
+      if: ${{ matrix.cfg.openeye == 'TRUE' }}
       with:
         python-version: ${{ matrix.python-version }}
         activate-environment: test
         channel-priority: true
         environment-file: devtools/conda-envs/test_env.yaml
         auto-activate-base: false
+
+    - uses: goanpeca/setup-miniconda@v1
+      name: Install only RDKit
+      if: ${{ matrix.cfg.openeye == 'FALSE' }}
+      with:
+        python-version: ${{ matrix.python-version }}
+        activate-environment: test
+        channel-priority: true
+        environment-file: devtools/conda-envs/rdkit_env.yaml
+        auto-activate-base: false
+
+    - name: Check installed toolkits
+      shell: bash -l {0}
+      run: |
+        if [[ "$OPENEYE" == true ]]; then
+          python -c "from openforcefield.utils.toolkits import OPENEYE_AVAILABLE; assert OPENEYE_AVAILABLE, 'OpenEye unavailable'"
+        fi
+        if [[ "$OPENEYE" == false ]]; then
+          if [[ $(conda list | grep openeye-toolkits) ]]; then
+            conda remove --force openeye-toolkits --yes
+          fi
+          python -c "from openforcefield.utils.toolkits import OPENEYE_AVAILABLE; assert not OPENEYE_AVAILABLE, 'OpenEye unexpectedly found'"
+        fi
 
     - name: Additional info about the build
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,11 @@ name: ci
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: ci
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,10 +3,10 @@ name: lint
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,11 @@ name: lint
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 jobs:
 

--- a/devtools/conda-envs/rdkit_env.yaml
+++ b/devtools/conda-envs/rdkit_env.yaml
@@ -2,7 +2,6 @@ name: test
 channels:
   - conda-forge
   - omnia
-  - openeye
 dependencies:
     # Base depends
   - python
@@ -12,7 +11,6 @@ dependencies:
   - openforcefield >= 0.7.2
 
     # Optional depends
-  - openeye-toolkits
 
     # Testing
   - pytest


### PR DESCRIPTION
## Description
This PR cleans up some loose ends in the CI script and sets up separate builds with and without OpenEye toolkits. Both builds have RDKit installed.