### PR TITLE
Add utility function to check version of dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ CMILES              	0.1.5
 
 Generate conformers from a starting structure, and minimize them using an OpenFF force field. Toolkit wrappers in the OpenFF Toolkit is used to call either [The RDKit](https://open-forcefield-toolkit.readthedocs.io/en/0.7.2/api/generated/openforcefield.utils.toolkits.RDKitToolkitWrapper.html#openforcefield.utils.toolkits.RDKitToolkitWrapper) or [OpenEye Omega](https://open-forcefield-toolkit.readthedocs.io/en/0.7.2/api/generated/openforcefield.utils.toolkits.OpenEyeToolkitWrapper.html#openforcefield.utils.toolkits.OpenEyeToolkitWrapper) to generate conformers, which are then energy-minimized with OpenMM.
 
+This requires [`OpenFF Toolkit`](https://github.com/openforcefield/openforcefield) version 0.7.1 or newer.
+
 ```shell
 $ python openff/cli/generate_conformers.py --help
 usage: generate_conformers.py [-h] -t TOOLKIT -f FORCEFIELD -m MOLECULE

--- a/openff/cli/generate_conformers.py
+++ b/openff/cli/generate_conformers.py
@@ -8,6 +8,8 @@ from openforcefield.typing.engines.smirnoff import ForceField
 from openforcefield.utils.toolkits import ToolkitRegistry
 from simtk import openmm, unit
 
+from openff.cli.utils.utils import _enforce_dependency_version
+
 
 def generate_conformers(
     molecule: str,
@@ -16,6 +18,8 @@ def generate_conformers(
     constrained: bool = False,
     prefix: Optional[str] = None,
 ) -> List[Molecule]:
+
+    _enforce_dependency_version("openforcefield", "0.7.1.")
 
     ff_name = forcefield
     if constrained:

--- a/openff/cli/tests/test_utils.py
+++ b/openff/cli/tests/test_utils.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def test_dependency_version_check():
+    """Ensure that runtime dependency checks are enforced"""
+    from openff.cli.utils.utils import _enforce_dependency_version
+
+    _enforce_dependency_version("openforcefield", "0.6.0")
+
+    with pytest.raises(
+        AssertionError, match="Need at least version 400.0.0 of package openforcefield"
+    ):
+        _enforce_dependency_version("openforcefield", "400.0.0")

--- a/openff/cli/utils/utils.py
+++ b/openff/cli/utils/utils.py
@@ -1,0 +1,17 @@
+def _enforce_dependency_version(package, minimum_version):
+    """
+    Raise an exception if the toolkit version is less than a minimum version
+    """
+    import pkg_resources
+
+    package_version = pkg_resources.get_distribution(package).version
+    major, minor, patch = package_version.split(".")[:3]
+    patch = patch.split("+")[0]
+    minimum_version = minimum_version.split(".")[:3]
+    assert all(
+        [
+            int(major) >= int(minimum_version[0]),
+            int(minor) >= int(minimum_version[1]),
+            int(patch) >= int(minimum_version[2]),
+        ]
+    ), f"Need at least version {'.'.join(minimum_version)} of package {package}"


### PR DESCRIPTION
## Description
In #4, we agreed to enforce OpenFF Toolkit >=0.7.1, but this was never enforced in the code. This PR adds a small utility function to enforce that some package is at least some minimum version. It only works for semantic versions, and probably not everything, but it works for the "cookiecutter-like" cases I checked. For now, it's only needed to check our own packages, which follow this pattern.