### PR TITLE
Fix version checking

### DIFF
--- a/openff/cli/utils/utils.py
+++ b/openff/cli/utils/utils.py
@@ -9,4 +9,4 @@ def _enforce_dependency_version(package, minimum_version):
 
     assert parse(package_version) > parse(
         minimum_version
-    ), "Need at least version {'.'.join(minimum_version)} of package {package}"
+    ), f"Need at least version {minimum_version} of package {package}"

--- a/openff/cli/utils/utils.py
+++ b/openff/cli/utils/utils.py
@@ -3,15 +3,10 @@ def _enforce_dependency_version(package, minimum_version):
     Raise an exception if the toolkit version is less than a minimum version
     """
     import pkg_resources
+    from packaging.version import parse
 
     package_version = pkg_resources.get_distribution(package).version
-    major, minor, patch = package_version.split(".")[:3]
-    patch = patch.split("+")[0]
-    minimum_version = minimum_version.split(".")[:3]
-    assert all(
-        [
-            int(major) >= int(minimum_version[0]),
-            int(minor) >= int(minimum_version[1]),
-            int(patch) >= int(minimum_version[2]),
-        ]
-    ), f"Need at least version {'.'.join(minimum_version)} of package {package}"
+
+    assert parse(package_version) > parse(
+        minimum_version
+    ), "Need at least version {'.'.join(minimum_version)} of package {package}"


### PR DESCRIPTION
## Description
I had a feeling the previous implementation was bad, and it was. That logic fails, thinking that `0.8.0` < `0.7.1`. Unsurprisingly, there's an off-the-shelf solution here.