### PR TITLE
Use click

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,54 +21,55 @@ python -m pip install .
 
 # Usage
 
-## `check_versions.py`
+## `openff check_versions`
 
 A simple utility to print the OpenFF packages found to be installed, and their versions
 
 ```shell
-$ python openff/cli/check_versions.py
+$ openff check_versions
 Found the following packages installed
 Package name        	Version
 ------------            -------
-OpenFF Toolkit      	0.7.2
-Openforcefields     	1.2.1
+OpenFF Toolkit      	0.8.0
+Openforcefields     	1.3.0
 OpenFF Evaluator    	Not found
 OpenFF System       	Not found
-OpenFF CLI          	Not found
-CMILES              	0.1.5
+OpenFF CLI          	0.0.0+100.ge013bfc.dirty
+CMILES              	v0.1.6
 ```
 
-## `generate_conformers.py`
+## `openff generate_conformers`
 
 Generate conformers from a starting structure, and minimize them using an OpenFF force field. Toolkit wrappers in the OpenFF Toolkit is used to call either [The RDKit](https://open-forcefield-toolkit.readthedocs.io/en/0.7.2/api/generated/openforcefield.utils.toolkits.RDKitToolkitWrapper.html#openforcefield.utils.toolkits.RDKitToolkitWrapper) or [OpenEye Omega](https://open-forcefield-toolkit.readthedocs.io/en/0.7.2/api/generated/openforcefield.utils.toolkits.OpenEyeToolkitWrapper.html#openforcefield.utils.toolkits.OpenEyeToolkitWrapper) to generate conformers, which are then energy-minimized with OpenMM.
 
 This requires [`OpenFF Toolkit`](https://github.com/openforcefield/openforcefield) version 0.7.1 or newer.
 
 ```shell
-$ python openff/cli/generate_conformers.py --help
-usage: generate_conformers.py [-h] -t TOOLKIT -f FORCEFIELD -m MOLECULE
-                              [-r RMS_CUTOFF] [-p PREFIX]
-                              [--constrained CONSTRAINED]
+$ openff generate_conformers --help
+Usage: openff generate_conformers [OPTIONS]
 
-Generate conformers with cheminformatics toolkits
+  Generate conformers from a starting structure, and minimize them using an
+  OpenFF force field.
 
-required arguments:
-  -t TOOLKIT, --toolkit TOOLKIT
-                        Name of the underlying cheminformatics toolkit to use.
-                        Accepted values are openeye and rdkit
-  -f FORCEFIELD, --forcefield FORCEFIELD
-                        Name of the force field to use, i.e. openff-1.0.0
-  -m MOLECULE, --molecule MOLECULE
-                        Path to an input file containing a molecule(s)
+Options:
+  -t, --toolkit [openeye|rdkit]  Name of the underlying cheminformatics
+                                 toolkit to use. Accepted values are openeye
+                                 and rdkit  [required]
 
-optional arguments:
-  -r RMS_CUTOFF, --rms-cutoff RMS_CUTOFF
-                        The redundancy cutoff between pre-minimized conformers
-  -p PREFIX, --prefix PREFIX
-                        The prefix for filenames of output molecules
-  --constrained CONSTRAINED
-                        Whether or not to use a constrained version of the
-                        force field
+  -f, --forcefield TEXT          Name of the force field to use, i.e.
+                                 openff-1.0.0  [required]
+
+  -m, --molecule TEXT            Path to an input file containing a
+                                 molecule(s)  [required]
+
+  -r, --rms-cutoff FLOAT         The redundancy cutoff between pre-minimized
+                                 conformers
+
+  -p, --prefix TEXT              The prefix for filenames of output molecules
+  --constrained BOOLEAN          Whether or not to use a constrained version
+                                 of the force field
+
+  --help                         Show this message and exit.
 ```
 
 ### Examples:
@@ -76,7 +77,7 @@ optional arguments:
 Generate conformers from a molecule in an SDF file, using The RDKit to sample conformers, and minimizing with OpenFF 1.2.0 "Parsley":
 
 ```shell
-$ python openff/cli/generate_conformers.py --molecule x.sdf --toolkit rdkit --forcefield openff-1.2.0
+$ openff generate_conformers --molecule x.sdf --toolkit rdkit --forcefield openff-1.2.0
 ```
 
 This produces many files named `molecule_N.sdf` where N begins at 0 for the lowest-energy conformer and increases with increasing conformer energy. In this case, 97 conformers were generated:
@@ -88,7 +89,7 @@ $ ls molecule_*.sdf | wc -l
 Do the same, but with OpenEye Omega, OpenFF 1.0 "Parsley," and a save the conformers in files starting with `coolmol`:
 
 ```shell
-$ python openff/cli/generate_conformers.py --molecule molecule.sdf --toolkit openeye --forcefield openff-1.0.0 --prefix coolmol
+$ openff generate_conformers --molecule molecule.sdf --toolkit openeye --forcefield openff-1.0.0 --prefix coolmol
 ```
 
 In this case, 101 conformers were generated, following the same naming scheme:

--- a/devtools/conda-envs/rdkit_env.yaml
+++ b/devtools/conda-envs/rdkit_env.yaml
@@ -6,6 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
+  - click
 
     # OpenFF stack
   - openforcefield >= 0.7.2

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -7,6 +7,7 @@ dependencies:
     # Base depends
   - python
   - pip
+  - click
 
     # OpenFF stack
   - openforcefield >= 0.7.2

--- a/openff/cli/check_versions.py
+++ b/openff/cli/check_versions.py
@@ -1,6 +1,14 @@
 import importlib
+import logging
 
 import click
+
+# The OpenFF toolkit's use of the logging modules prints its "you don't have
+# OpenEye installed" error to STDERR. We do not wish to capture this here, so
+# set the minimum logging level to ERROR. See
+# https://docs.python.org/3/library/logging.html#logging-levels
+
+logging.getLogger("openforcefield").setLevel(logging.ERROR)
 
 
 def get_versions():

--- a/openff/cli/check_versions.py
+++ b/openff/cli/check_versions.py
@@ -1,5 +1,7 @@
 import importlib
 
+import click
+
 
 def get_versions():
     packages = {
@@ -29,7 +31,7 @@ def get_versions():
     return out
 
 
-if __name__ == "__main__":
-    # TODO: Have this function return the string, without printing above
-    #  or return an exit code here
-    print(get_versions())
+@click.command("check_versions")
+def check_versions_command():
+    """Check the installed versions of OpenFF software."""
+    click.echo(get_versions())

--- a/openff/cli/cli.py
+++ b/openff/cli/cli.py
@@ -1,0 +1,15 @@
+import click
+
+from openff.cli.check import check_value_command
+from openff.cli.check_versions import check_versions_command
+from openff.cli.generate_conformers import generate_conformers_command
+
+
+@click.group()
+def cli():
+    """Command line utilities for the Open Force Field software stack"""
+
+
+cli.add_command(check_value_command)
+cli.add_command(check_versions_command)
+cli.add_command(generate_conformers_command)

--- a/openff/cli/cli.py
+++ b/openff/cli/cli.py
@@ -2,6 +2,7 @@ import click
 
 from openff.cli.check_versions import check_versions_command
 from openff.cli.generate_conformers import generate_conformers_command
+from openff.cli.get_conformer_energies import get_conformer_energies_command
 
 
 @click.group()
@@ -11,3 +12,4 @@ def cli():
 
 cli.add_command(check_versions_command)
 cli.add_command(generate_conformers_command)
+cli.add_command(get_conformer_energies_command)

--- a/openff/cli/cli.py
+++ b/openff/cli/cli.py
@@ -1,6 +1,5 @@
 import click
 
-from openff.cli.check import check_value_command
 from openff.cli.check_versions import check_versions_command
 from openff.cli.generate_conformers import generate_conformers_command
 
@@ -10,6 +9,5 @@ def cli():
     """Command line utilities for the Open Force Field software stack"""
 
 
-cli.add_command(check_value_command)
 cli.add_command(check_versions_command)
 cli.add_command(generate_conformers_command)

--- a/openff/cli/get_conformer_energies.py
+++ b/openff/cli/get_conformer_energies.py
@@ -44,12 +44,6 @@ def get_conformer_energies(
         else:
             mols.append(molecule)
 
-    n_molecules = len(mols)
-    n_conformers = sum([mol.n_conformers for mol in mols])
-    print(
-        f"{n_molecules} unique molecule(s) loaded, with {n_conformers} total conformers"
-    )
-
     ff = _get_forcefield(forcefield, constrained)
 
     mols_with_charges = []
@@ -98,30 +92,35 @@ def get_conformer_energies(
 
 
 def _print_mol_data(mols):
+    out = ""
+
+    n_molecules = len(mols)
+    n_conformers = sum([mol.n_conformers for mol in mols])
+    out += f"{n_molecules} unique molecule(s) loaded, with {n_conformers} total conformers\n"
+
     pre_key = "original conformer energies (kcal/mol)"
     min_key = "minimized conformer energies (kcal/mol)"
     rmsd_key = "RMSD of minimized conformers (angstrom)"
     for mol_idx, mol in enumerate(mols):
         forcefield = mol.properties["minimized against: "]
-        print(f"Conformer energies of mol {mol.name}, minimized against {forcefield}")
-        print(
-            "Conformer         Initial PE         Minimized PE       "
-            "RMS between initial and minimized conformer"
+        out += f"Conformer energies of mol {mol.name}, minimized against {forcefield}\n"
+        out += (
+            "Conformer         Initial PE         Minimized PE       \n"
+            "RMS between initial and minimized conformer\n"
         )
         for conformer_idx in range(mol.n_conformers):
             pre_energy = mol.properties[pre_key][conformer_idx]
             min_energy = mol.properties[min_key][conformer_idx]
             rmsd = mol.properties[rmsd_key][conformer_idx]
-            print(
-                "%5d / %5d : %8.3f kcal/mol %8.3f kcal/mol  %8.3f Angstroms"
-                % (
-                    conformer_idx + 1,
-                    mol.n_conformers,
-                    pre_energy / unit.kilocalories_per_mole,
-                    min_energy / unit.kilocalories_per_mole,
-                    rmsd,
-                )
+            out += "%5d / %5d : %8.3f kcal/mol %8.3f kcal/mol  %8.3f Angstroms\n" % (
+                conformer_idx + 1,
+                mol.n_conformers,
+                pre_energy / unit.kilocalories_per_mole,
+                min_energy / unit.kilocalories_per_mole,
+                rmsd,
             )
+
+    return out
 
 
 # TODO: Maybe use https://github.com/click-contrib/click-option-group
@@ -169,4 +168,4 @@ def get_conformer_energies_command(
         constrained=constrained,
     )
 
-    _print_mol_data(mols)
+    click.echo(_print_mol_data(mols))

--- a/openff/cli/get_conformer_energies.py
+++ b/openff/cli/get_conformer_energies.py
@@ -1,6 +1,6 @@
-import argparse
 from typing import List
 
+import click
 from openforcefield.topology import Molecule
 from openforcefield.utils.toolkits import ToolkitRegistry
 from simtk import unit
@@ -124,51 +124,49 @@ def _print_mol_data(mols):
             )
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Evaluate conformer energies with OpenMM"
-    )
-    parser._action_groups.pop()
-    required_args = parser.add_argument_group("required arguments")
-    optional_args = parser.add_argument_group("optional arguments")
-
-    required_args.add_argument(
-        "-t",
-        "--toolkit",
-        type=str,
-        required=True,
-        help="Name of the underlying cheminformatics toolkit to use. Accepted"
-        " values are openeye and rdkit",
-    )
-    required_args.add_argument(
-        "-f",
-        "--forcefield",
-        type=str,
-        required=True,
-        help="Name of the force field to use, i.e. openff-1.0.0",
-    )
-    required_args.add_argument(
-        "-m",
-        "--molecule",
-        type=str,
-        required=True,
-        help="Path to an input file containing a molecule(s), single or multi-conformers",
-    )
-    optional_args.add_argument(
-        "--constrained",
-        type=bool,
-        default=False,
-        help="Whether or not to use a constrained version of the force field",
-    )
-    args = parser.parse_args()
-
-    registry = make_registry(args.toolkit)
+# TODO: Maybe use https://github.com/click-contrib/click-option-group
+@click.command("get_conformer_energies")
+@click.option(
+    "-t",
+    "--toolkit",
+    type=click.Choice(["openeye", "rdkit"]),
+    required=True,
+    help="Name of the underlying cheminformatics toolkit to use. Accepted values are openeye and rdkit",
+)
+@click.option(
+    "-f",
+    "--forcefield",
+    type=str,
+    required=True,
+    help="Name of the force field to use, i.e. openff-1.0.0",
+)
+@click.option(
+    "-m",
+    "--molecule",
+    type=str,
+    required=True,
+    help="Path to an input file containing a molecule(s)",
+)
+@click.option(
+    "--constrained",
+    type=bool,
+    default=False,
+    help="Whether or not to use a constrained version of the force field",
+)
+def get_conformer_energies_command(
+    toolkit,
+    forcefield,
+    molecule,
+    constrained,
+):
+    """Evaluate conformer energies with OpenMM"""
+    registry = make_registry(toolkit)
 
     mols = get_conformer_energies(
-        molecule=args.molecule,
+        molecule=molecule,
         registry=registry,
-        forcefield=args.forcefield,
-        constrained=args.constrained,
+        forcefield=forcefield,
+        constrained=constrained,
     )
 
     _print_mol_data(mols)

--- a/openff/cli/tests/test_cli_calls.py
+++ b/openff/cli/tests/test_cli_calls.py
@@ -1,13 +1,9 @@
-import pathlib
 import subprocess
 import tempfile
 
 from openforcefield.utils import temporary_cd
 
-from openff.cli import __file__ as cli_path
-
 # TODO: Run tests from tempdirs
-CLI_ROOT = pathlib.Path(cli_path).joinpath("../../../").resolve()
 
 
 class TestCLICalls:
@@ -35,7 +31,7 @@ class TestCheckVersionsCalls(TestCLICalls):
 
         from openff.cli import __version__ as cli_version
 
-        out, _ = self.call(f"python {CLI_ROOT}/openff/cli/check_versions.py")
+        out, _ = self.call("openff check_versions")
         # TODO: Use regex to connect package names with versions
         assert toolkit_version in out
         assert cli_version in out
@@ -47,12 +43,8 @@ class TestGenerateConformersCalls(TestCLICalls):
         # TODO: This should maybe fail before checking the toolkit,
         #  based on missing required arguments
         _, err = self.call(
-            (
-                f"python {CLI_ROOT}/openff/cli/generate_conformers.py "
-                "--forcefield openff-1.0.0 --toolkit magic "
-                "--molecule molecule.sdf"
-            ),
+            "openff generate_conformers --forcefield openff-1.0.0 --toolkit magic --molecule molecule.sdf",
             raise_err=False,
         )
-        assert "openff.cli.utils.exceptions.UnsupportedToolkitError" in err
-        assert "magic" in err
+        assert "Error: Invalid value for '-t' / '--toolkit':" in err
+        assert "invalid choice: magic. (choose from openeye, rdkit)" in err

--- a/setup.py
+++ b/setup.py
@@ -56,4 +56,6 @@ setup(
     # Manual control if final package is compressible or not, set False to prevent the .egg from being made
     # zip_safe=False,
 
+    # Set up the main CLI entry points
+    entry_points={"console_scripts": ["openff=openff.cli:cli"]},
 )


### PR DESCRIPTION
### Description
This PR refactors the CLI-facing components to use `click` over `argparse`. Some things I encountered while doing this:
* I have written the base command to be `openff`, which I beleive balances the below constraints. I welcome feedback so as to not single-handedly make this decision on a user-facing point. (This is not at all binding, however).
  * **unique**: it's unlikely to be confused with another tool installed into a user's `$PATH`
  * **descriptive**: easily connected to the initiative by said user(s), whereas something like `off` might not be
  * **concise**: not hard to type out, compared to something longer, like a ridiculous-looking `openforcefield-command-line-tools`
* It's no longer easy to throw a custom exception with bad args, although not impossible, and not necessarily bad. See the difference in the `test_unsupported_toolkit` test, in which a custom exception I wrote to be descriptive is now replaced with a descriptive `click` error.
* The code is still more verbose than it probably needs to be, and could probably cleaned up by factoring out the common ones to a single place
* In order to make the main functions re-usable from Python, I had to use a pattern of duplicating the driver functions with their `click` equivalent, which are _not_ directly callable from within Python.
* The docstrings of the functions decorated with `click.command` or similar are exposed to the user in the help, like in this dummy function
```
$ openff run --help
Usage: openff run [OPTIONS] VALUE

  my cool docstring

Options:
  --help  Show this message and exit.
```

Any previous usage like `python openff/cli/do_thing.py` should be 1:1 replacable with `openff do_thing`, args and all. The simplest one:

```
$ openff check_versions
Found the following packages installed
Package name        	Version
------------            -------
OpenFF Toolkit      	0.8.0
Openforcefields     	1.3.0
OpenFF Evaluator    	Not found
OpenFF System       	Not found
OpenFF CLI          	0.0.0+97.gd768450
CMILES              	v0.1.6
```
or one with args
```
$ openff generate_conformers --molecule molecule.sdf --forcefield openff-1.3.0 --toolkit rdkit
# no output, but it seems to run the same as before
```

Would resolve #6

### TODO:
* [ ] Replace other `print()` with `click.echo`
* [ ] Update README examples